### PR TITLE
get Ziti id config JSON from env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ buildtests: $(DIST_PATH)/go-httpbin.test
 
 $(DIST_PATH)/go-httpbin: $(GO_SOURCES)
 	mkdir -p $(DIST_PATH)
-	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(DIST_PATH)/go-httpbin ./cmd/go-httpbin
+	CGO_ENABLED=1 go build -ldflags="-s -w" -o $(DIST_PATH)/go-httpbin ./cmd/go-httpbin
 
 $(DIST_PATH)/go-httpbin.test: $(GO_SOURCES)
-	CGO_ENABLED=0 go test -ldflags="-s -w" -v -c -o $(DIST_PATH)/go-httpbin.test ./httpbin
+	CGO_ENABLED=1 go test -ldflags="-s -w" -v -c -o $(DIST_PATH)/go-httpbin.test ./httpbin
 
 clean:
 	rm -rf $(DIST_PATH) $(COVERAGE_PATH)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ variables (or a combination of the two):
 | `-ziti-identity` | `ZITI_IDENTITY` | Ziti identity json file location | - |
 | `-ziti-name` | `ZITI_SERVICE_NAME` | Name of Ziti Service to bind against | - |
 
-**Note:** Command line arguments take precedence over environment variables.
+**Notes:**
 
+* Command line arguments take precedence over environment variables.
+* As an alternative to supplying `ziti-identity` as a file you may define environment variable `ZITI_IDENTITY_JSON`.
 
 ### Standalone binary
 


### PR DESCRIPTION
This adds the option to get the Ziti identity config from env var while preserving the existing env var and command line option precedence and behavior.