### PR TITLE
ci: add test-docker-publish workflow for verifying registry auth

### DIFF
--- a/.github/workflows/test-docker-publish.yaml
+++ b/.github/workflows/test-docker-publish.yaml
@@ -1,0 +1,56 @@
+# Manually triggered workflow to verify Docker Hub login and push
+# machinery works with the org's secrets and vars. Builds and pushes
+# an image tagged with the git ref (branch, tag, or SHA).
+
+name: Test Docker Publish
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_REPO: ${{ vars.GO_HTTPBIN_CONTAINER_IMAGE_REPO || 'openziti/go-httpbin' }}
+
+jobs:
+  test-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_REPO }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
+      - name: Set Up Docker BuildKit
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.DOCKER_HUB_API_USER || secrets.DOCKER_HUB_API_USER }}
+          password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
+
+      - name: Build & Push Multi-Platform Container Image
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          push: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.github
 *.exe
 *.test
 *.prof


### PR DESCRIPTION
Manual workflow_dispatch trigger to verify Docker Hub login and push works with the org's secrets/vars before cutting a real release. Uses docker/metadata-action to tag from the git ref.

Also exclude .github from the .* gitignore rule so new workflow files don't require force-adding.