### PR TITLE
ci: strip v prefix from docker image tags on tag refs

### DIFF
--- a/.github/workflows/test-docker-publish.yaml
+++ b/.github/workflows/test-docker-publish.yaml
@@ -25,7 +25,7 @@ jobs:
           images: ${{ env.IMAGE_REPO }}
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
+            type=semver,pattern={{version}},event=tag
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Use semver pattern in docker/metadata-action for tag events so that pushing v2.19.0_1.4.2 produces image tag 2.19.0_1.4.2, not v2.19.0_1.4.2. Branch refs are unaffected.